### PR TITLE
add target - performanc calculations wind events removed

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -669,6 +669,29 @@ list(
   ) %>% 
       set_names(names(zonal_stats_high_risk_hull))
   ),
+  # run performance calculations  on clustered data
+  tar_target(
+      name =tbl_performance_area_clustered5_b7f7_wind_rm,
+      command = names(zonal_stats_high_risk_hull) %>% 
+          map(\( nm_tbl){
+              clustered_performance_calcs(
+                  impact = marib_hajjah_cccm_flood_clustered5 %>% 
+                      filter(
+                          # this whole cluster appears to be wind damage rather than rainfall
+                          cluster !="Hajjah_2",
+                          # confirmed that this particular event was wind rather than rainfall
+                          !(site_id =="YE2613_1961"  & date =="2022-04-30")
+                      ),
+                  rainfall = zonal_stats_high_risk_hull,
+                  precip_regime = nm_tbl,
+                  date = "date",
+                  look_ahead = 7,
+                  look_back = 7
+              )  
+          }
+  ) %>% 
+      set_names(names(zonal_stats_high_risk_hull))
+  ),
   # Impact vs Rainfall & Return period ------------------------------------------------
   
   # in this section we make plots showing a.) rainfall over flood reporting period, b.  2,3,4,5 return return period

--- a/_targets/meta/meta
+++ b/_targets/meta/meta
@@ -1,5 +1,5 @@
 name|type|data|command|depend|seed|path|time|size|bytes|format|repository|iteration|parent|children|seconds|warnings|error
-.Random.seed|object|859c0c84ec4584cf|||||||||||||||
+.Random.seed|object|20242a8f459d8b1e|||||||||||||||
 adm_sf|stem|d814208e77634ebe|c0460a3bc14ebd57|5b6883bff12d4128|421735004||t19419.4297679868s|6e36be5798e8a713|6111599|rds|local|vector|||0.124||
 alos_landform_lookup|object|b415a69efa003277|||||||||||||||
 calc_rolling_precip_sites|function|6dc98d60d6e9b310|||||||||||||||
@@ -101,6 +101,7 @@ tbl_performance_30d_overall|stem|40508babf31603e2|81e821f6d624fd01|9ca2dbb7bdc59
 tbl_performance_5d_gov|stem|47352c95120758c7|7f2fc6fdb3a4f8f6|9ca2dbb7bdc5966f|1884672460||t19430.5291091727s|77f068c734313148|13028|rds|local|vector|||0.069||
 tbl_performance_5d_overall|stem|40508babf31603e2|81e821f6d624fd01|9ca2dbb7bdc5966f|1178185053||t19430.5291083201s|5297c7031d8b752c|4149|rds|local|vector|||0.293||
 tbl_performance_area_clustered5_b7f7|stem|606ba209292d14d7|af81f0a3fe876674|0ea1c6ac5c8f33b3|-1112629018||t19446.7194797789s|df446457e9875fd5|4394|rds|local|vector|||53.894||
+tbl_performance_area_clustered5_b7f7_wind_rm|stem|ff1abd4819834f4e|8e6ad88842655e12|af3402a576b2bf7b|1643122249||t19450.1885006637s|a3cc22060fb1a10f|4373|rds|local|vector|||50.451||
 tbl_performance_area_marib_hajjah|stem|46ed0878aff97a30|650cb650d3895281|6abe882f095baac9|635551685||t19446.7232162703s|65e151d8ed55e831|48889|rds|local|vector|||0.497||
 tbl_performance_gov_area_level|stem|e5a8f2e23fe7018b|6efed91c6e8e6c87|c9806a4d965ab708|-1652714346||t19446.7231814529s|0f532ef5852f63e7|34335|rds|local|vector|||319.792||
 tbl_performance_overall|stem|4a29f5171b810b6d|7198b9fbd6ceaf73|c2a19dc197dd591b|-875938684||t19446.7231940373s|7da544d15fc2db6b|73983|rds|local|vector|||1.062||

--- a/exploration/03_chirps_vs_floodscan.qmd
+++ b/exploration/03_chirps_vs_floodscan.qmd
@@ -4,19 +4,15 @@ format: html
 editor: visual
 ---
 
-
 **Note:** This notebook contains some exploratory analysis to better understand the data sets. It is not currently being used in the pipeline or for any outputs, but we may return to it and adopt some code later on.
 
 # Flood Scan vs Chirps
 
-
 The notebook offers a first look at/exploration of:
 
-1. chirps vs floodscan. However, both dataset are aggregated to admin zones which we realized later is not ideal.
-2. cccm data - some exploration to understand how the data is structured and what variables might be important
-3. looking into a way to load and use floodscan in R - so far unsuccessful
-
-
+1.  chirps vs floodscan. However, both dataset are aggregated to admin zones which we realized later is not ideal.
+2.  cccm data - some exploration to understand how the data is structured and what variables might be important
+3.  looking into a way to load and use floodscan in R - so far unsuccessful
 
 ```{r}
 library(tidyverse)
@@ -109,8 +105,6 @@ fs_ts$floodscan_stats_ADM1_PCODE.csv %>%
 # I can tell from the pic of flood scan coverage that theese are not covered...
 ```
 
-
-
 plot some flood scan vs chirps. This data is aggregated at the national level in both floodscan and chirps. This is probably not ideal
 
 interesting... are the very low values noise in the floodscan?
@@ -144,7 +138,6 @@ fs_chirps_adm0 %>%
   scale_y_log10(labels = scales::percent) +
   labs(x = "10-day rolling sum max (mm)", y = "Sum flood fraction")
 ```
-
 
 Now at the admin 1 level
 
@@ -278,8 +271,6 @@ plot(fit_chirps_daily)
 plot(fit_chirps_10d)
 ```
 
-
-
 # Rainfall vs affected
 
 ```{r}
@@ -342,25 +333,4 @@ fs_chirps_cm %>%
   geom_point() +
   scale_y_log10() +
   scale_x_log10()
-```
-
-
-```{r}
-fsrp <- file.path(
-  Sys.getenv("AA_DATA_DIR"),
-  "private/raw/glb/floodscan/floodscan_flooded_fraction_africa_19980112-20221231_p00/aer_sfed_area_300s_19980112_20221231_v05r01.nc"
-)
-
-fsr <- terra::sds(fsrp)
-
-
-fsr <- terra:::rast(raster::stack(fsrp))
-fsr <- terra::rast(fsrp)
-raster::raster(fsr)
-plot(fsr[[1]])
-
-fsr %>% summary()
-plot(fsr)
-name(fsr)
-terra::subset(fsr)
 ```


### PR DESCRIPTION
just added target to do performance classifications on data with wind events removed from flood report db. Can merge into prev branch `assess-IMERG-latency` or switch to `main` if we merge that first.