### PR TITLE
add calculation for gefs 2 year RP based on mean of LT 3:7

### DIFF
--- a/exploration/10_CHIRPS_GEFS.Rmd
+++ b/exploration/10_CHIRPS_GEFS.Rmd
@@ -115,6 +115,35 @@ gefs_rps %>%
     )
 ```
 
+## GEFS 2 year RP averaged LT 3-7
+
+Previously were using CHIRPS 1981-2022 for RP calcs.
+
+Below we calculate chirps-gefs RP 2 for all available data (2000-2022) and compare that to chirps RP=2 2000-2022
+```{r}
+gefs_mean_rp <- gefs_rps %>% 
+    filter(
+        RP==2,
+        leadtime %in% c(3:7)
+           ) %>% 
+    group_by(governorate_name) %>% 
+    summarise(
+        estimate_gefs = mean(estimate)
+    )
+    
+chirps_2000_2022_rp %>% 
+    filter(RP==2) %>% 
+    rename(
+        estimate_chirps=estimate
+    ) %>% 
+    left_join(gefs_mean_rp) %>% 
+    mutate(
+        diff_estimate = estimate_gefs-estimate_chirps
+    ) %>% 
+    select(governorate_name,RP,estimate_chirps,estimate_gefs,diff_estimate)
+    
+```
+
 ## ECMWF HRES & ERA5
 
 - Filter both data sets to 2007-2022


### PR DESCRIPTION
just added a small section to the notebook to calculate the average 2 year RP  (over leadtimes `3:7`) for CHIRPS-GEFS. 

My plan is to:
1. merge to main so I can then
2.  create a small GHA workflow branch where I adjust the threshold in email auto-alerts to this. We won't merge this to the main branch (for CRON schedule) yet.
3. But just produce a few emails with the new thresholds on manual workflow schedule

This PR doesn't actually change any email or trigger or alert, but thought the git history would be clearer/easier to follow if this was merged first. Also since this branch doesn't have any of the yaml/GH Actions configuration it's easier to merge this to main and create a new branch for manual GHA runs