### PR TITLE
Adjusted CHIRPS-GEFS LT python pipeline

### DIFF
--- a/src/datasource_extensions.py
+++ b/src/datasource_extensions.py
@@ -180,7 +180,7 @@ class ChirpsGefs(_DataSourceExtension):
     )
     _RUN_DATE_FORMAT = "%Y/%m/%d"
     _FORECAST_DATE_FORMAT = "%Y.%m%d"
-    _PROCESSED_FILENAME = "chirps-gefs_daily_high_risk_hulls_lt0.csv"
+    _PROCESSED_FILENAME = "chirps-gefs_daily_high_risk_hulls.csv"
 
     def __init__(
         self,
@@ -270,7 +270,7 @@ class ChirpsGefs(_DataSourceExtension):
         df_results_full = pd.DataFrame()
         for run_date in self._date_range:
             # Loop through all lead times
-            for leadtime in range(11):
+            for leadtime in range(11): # to read in day0 to day 11
                 df_output = self._process_single_file(
                     run_date=run_date,
                     leadtime=leadtime,
@@ -338,7 +338,7 @@ class ChirpsGefs(_DataSourceExtension):
                     pd.DataFrame(
                         {
                             "time": run_date,
-                            "leadtime": leadtime + 1,
+                            "leadtime": leadtime + 1, # to set day0 to LT=1
                             "value": da_hull.values,
                             "gov": row.gvrnrt_,
                         }


### PR DESCRIPTION
@zackarno , finally got some time last week to make the changes quickly. The daily CSV file should now have LT=0 and is saved as `chirps-gefs_daily_high_risk_hulls_lt0.csv`