### PR TITLE
adjust email text to only say activation if breach is in 1:7 lts

### DIFF
--- a/src/email/email.Rmd
+++ b/src/email/email.Rmd
@@ -79,6 +79,7 @@ trig_status_df <- thresholds %>%
   imap_dfr(\(num, gov){
     # by gov filter rows > thresh
     df_gte <- chirps_gefs_processed %>%
+        filter(leadtime %in% 1:7) |> 
       # for txt later
       mutate(
         gov_amt = glue("{governorate_name} ({cumu_3day_mm} mm)")


### PR DESCRIPTION
Just a hotfix since I flipped the monitoring back on as an internal experimental post monitoring for CHD and a few CERF colleagues. 

Previously text would say "activated" even threshold breached in leadtimes 1:10. This was wrong because lts 8:10 are just pre-alert.